### PR TITLE
Foreign Key now supported for User/Hive relationship

### DIFF
--- a/app/controllers/hives_controller.rb
+++ b/app/controllers/hives_controller.rb
@@ -14,7 +14,7 @@ class HivesController < ApplicationController
     if @hive.update(hive_params)
       head :no_content
     else
-      render json: @example.errors, status: :unprocessable_entity
+      render json: @hive.errors, status: :unprocessable_entity
     end
   end
 
@@ -37,7 +37,7 @@ class HivesController < ApplicationController
 
   def hive_params
     params.require(:hive).permit(:hive_name, :queen_type, :brood_supers,
-                                 :honey_supers, :hive_location)
+                                 :honey_supers, :hive_location, :user_id)
   end
   private :hive_params
 end

--- a/app/models/hive.rb
+++ b/app/models/hive.rb
@@ -1,2 +1,3 @@
 class Hive < ApplicationRecord
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 class User < ApplicationRecord
   include Authentication
-  has_many :examples
+  has_many :hives
 end

--- a/db/migrate/20170427203103_add_user_to_hives.rb
+++ b/db/migrate/20170427203103_add_user_to_hives.rb
@@ -1,0 +1,5 @@
+class AddUserToHives < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :hives, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170427153131) do
+ActiveRecord::Schema.define(version: 20170427203103) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,8 @@ ActiveRecord::Schema.define(version: 20170427153131) do
     t.string   "hive_location"
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
+    t.integer  "user_id"
+    t.index ["user_id"], name: "index_hives_on_user_id", using: :btree
   end
 
   create_table "users", force: :cascade do |t|
@@ -44,4 +46,5 @@ ActiveRecord::Schema.define(version: 20170427153131) do
   end
 
   add_foreign_key "examples", "users"
+  add_foreign_key "hives", "users"
 end

--- a/scripts/create_hive.sh
+++ b/scripts/create_hive.sh
@@ -11,8 +11,26 @@ curl "${API}${URL_PATH}" \
       "queen_type": "Russian",
       "brood_supers": 2,
       "honey_supers": 2,
-      "hive_location": "Amesbury, NH"
+      "hive_location": "Amesbury, NH",
+      "user_id": 1
     }
   }'
 
 echo
+API="${API_ORIGIN:-http://localhost:4741}"
+URL_PATH="/hives"
+curl "${API}${URL_PATH}" \
+  --include \
+  --request POST \
+  --header "Content-Type: application/json" \
+  --header "Authorization: Token token=$TOKEN" \
+  --data '{
+    "hive": {
+      "hive_name": "Hive Ten",
+      "queen_type": "Russian",
+      "brood_supers": 2,
+      "honey_supers": 2,
+      "hive_location": "Amesbury, NH",
+      "user_id": 1
+    }
+  }'

--- a/scripts/update_hive.sh
+++ b/scripts/update_hive.sh
@@ -1,5 +1,5 @@
 API="${API_ORIGIN:-http://localhost:4741}"
-URL_PATH="/hives/2"
+URL_PATH="/hives/3"
 curl "${API}${URL_PATH}" \
   --include \
   --request PATCH \
@@ -11,3 +11,15 @@ curl "${API}${URL_PATH}" \
       "honey_supers": 5
     }
   }'
+  API="${API_ORIGIN:-http://localhost:4741}"
+  URL_PATH="/hives/1"
+  curl "${API}${URL_PATH}" \
+    --include \
+    --request PATCH \
+    --header "Content-Type: application/json" \
+    --header "Authorization: Token token=$TOKEN" \
+    --data '{
+      "hive": {
+        "hive_name": "Hive Five"
+      }
+    }'


### PR DESCRIPTION
This required updates both Hive and User classes to update relationships.

Updated curl scripts to handle new user_id parameter.

Updated user_id to be one of the parameters that is permitted.

One issue resolved was belongs_to was set to 'users' s/b user this
caused a 422 error. Used rails console to see error.